### PR TITLE
Add client-side dashboard with run projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/games.html
+++ b/public/games.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>MLB Runs Snapshot</title>
+  <style>
+    body{font-family:sans-serif;margin:1rem;}
+    .controls{display:flex;gap:1rem;align-items:center;margin-bottom:1rem;}
+    .kpis{display:flex;gap:2rem;margin-bottom:1rem;}
+    .ticker{overflow:hidden;border:1px solid #ccc;margin-bottom:1rem;padding:.25rem 0;white-space:nowrap;}
+    #ticker-track{display:inline-block;animation:ticker 20s linear infinite;}
+    @keyframes ticker{from{transform:translateX(0);}to{transform:translateX(-50%);}}
+    .game{border:1px solid #ccc;border-radius:4px;padding:.5rem;margin-bottom:.5rem;}
+    .game__row{display:flex;justify-content:space-between;align-items:center;}
+    .team{display:flex;align-items:center;gap:.25rem;}
+    .team img{height:24px;width:24px;object-fit:contain;}
+    .game__meta{display:flex;justify-content:space-between;font-size:.85rem;margin-top:.25rem;}
+    .badge{padding:0 4px;border-radius:4px;background:#eee;font-size:.7rem;}
+    .badge--live{background:#d33;color:#fff;}
+    .badge--final{background:#555;color:#fff;}
+    .market-pill{background:#eee;padding:0 4px;border-radius:4px;font-size:.8rem;}
+    body.compact .game{padding:.25rem;font-size:.85rem;}
+  </style>
+</head>
+<body>
+  <div class="controls">
+    <button id="btn-refresh">Refresh</button>
+    <label><input type="checkbox" id="toggle-show-final"> Show finals</label>
+    <label><input type="checkbox" id="toggle-compact"> Compact view</label>
+  </div>
+  <div class="kpis">
+    <div>Total runs: <span id="kpi-total-runs">—</span></div>
+    <div>Projected finish: <span id="kpi-projected">—</span></div>
+  </div>
+  <div class="ticker"><div id="ticker-track"></div></div>
+  <div id="games-list"></div>
+
+<script>
+// ----- CONFIG / DATA WIRES -----
+// Expect your data fetchers to populate these:
+async function fetchGamesSnapshot(){
+  // TODO: wire to your server.
+  // Shape per game (example):
+  // {
+  //   id, state: "scheduled" | "in_progress" | "final",
+  //   inningStr: "Top 5th",
+  //   home: { abbr:"NYY", name:"Yankees", logo:"./assets/nyy.png", runs: 2 },
+  //   away: { abbr:"DET", name:"Tigers", logo:"./assets/det.png", runs: 1 },
+  //   runsSoFar: 3,
+  //   markets: {
+  //     liveMain: { line: 7.5, overOdds: -105, underOdds: -115 },
+  //     liveAlts: [ { line:6.5, overOdds:-145, underOdds:+125 }, { line:8.5, overOdds:+130, underOdds:-150 } ],
+  //     preMain: { line: 8.0, overOdds:-110, underOdds:-110 },
+  //     preAlts: [ /* ... */ ]
+  //   }
+  // }
+  return [];
+}
+
+// Your computeTwoNumbers from earlier (pasted verbatim)
+function americanToProbRaw(odds){ return odds>=0 ? 100/(odds+100) : (-odds)/((-odds)+100) }
+function devigTwoWay(pOverRaw,pUnderRaw){ const d=pOverRaw+pUnderRaw; const pOver=pOverRaw/d; return {pOver,pUnder:1-pOver} }
+function linInterp(x1,F1,x2,F2,target=.5){ if(F2===F1) return (x1+x2)/2; const t=(target-F1)/(F2-F1); return x1+t*(x2-x1) }
+function impliedMedianFromAlts(alts){
+  if(!alts||!alts.length) return null;
+  const pts = alts
+    .filter(a=>Number.isFinite(a.line)&&Number.isFinite(a.overOdds)&&Number.isFinite(a.underOdds))
+    .map(a=>{ const pOverRaw=americanToProbRaw(a.overOdds); const pUnderRaw=americanToProbRaw(a.underOdds); const {pUnder}=devigTwoWay(pOverRaw,pUnderRaw); return {line:a.line,F:pUnder} })
+    .sort((a,b)=>a.line-b.line);
+  if(!pts.length) return null;
+  for(let i=0;i<pts.length-1;i++){
+    const a=pts[i], b=pts[i+1];
+    if((a.F<=.5 && b.F>=.5) || (a.F>=.5 && b.F<=.5)) return linInterp(a.line,a.F,b.line,b.F,.5);
+  }
+  return pts.reduce((best,cur)=>Math.abs(cur.F-.5)<Math.abs(best.F-.5)?cur:best).line;
+}
+function marketImpliedTotal({ liveMain, liveAlts, preMain, preAlts }={}){
+  const liveMedian = impliedMedianFromAlts(liveAlts);
+  if(Number.isFinite(liveMedian)) return liveMedian;
+  if(Number.isFinite(liveMain?.line)) return liveMain.line;
+  const preMedian = impliedMedianFromAlts(preAlts);
+  if(Number.isFinite(preMedian)) return preMedian;
+  if(Number.isFinite(preMain?.line)) return preMain.line;
+  return null;
+}
+function computeTwoNumbers(games){
+  let totalRunsScored=0, expectedRemainingSum=0;
+  for(const g of games){
+    const A=Math.max(0,g.runsSoFar||0);
+    totalRunsScored+=A;
+    if(g.state!=="final"){
+      const Tstar=marketImpliedTotal(g.markets||{});
+      const rem=Number.isFinite(Tstar)?Math.max(Tstar-A,0):0;
+      expectedRemainingSum+=rem;
+    }
+  }
+  return { totalRunsScored, projectedSlateFinish: totalRunsScored+expectedRemainingSum };
+}
+
+// ----- RENDERING -----
+const elKpiTotal = document.getElementById('kpi-total-runs');
+const elKpiProj  = document.getElementById('kpi-projected');
+const elGames    = document.getElementById('games-list');
+const elTicker   = document.getElementById('ticker-track');
+
+const btnRefresh = document.getElementById('btn-refresh');
+const toggleFinal= document.getElementById('toggle-show-final');
+const toggleCompact = document.getElementById('toggle-compact');
+
+toggleCompact.addEventListener('change',()=> {
+  document.body.classList.toggle('compact', toggleCompact.checked);
+});
+
+btnRefresh.addEventListener('click', hydrate);
+
+toggleFinal.addEventListener('change', hydrate);
+
+function gameBadge(state){
+  if(state==="in_progress") return '<span class="badge badge--live">LIVE</span>';
+  if(state==="final") return '<span class="badge badge--final">FINAL</span>';
+  return '<span class="badge">SCHEDULED</span>';
+}
+function gameCard(g){
+  const showFinals = toggleFinal.checked;
+  if(g.state==="final" && !showFinals) return '';
+  const score = `${g.away.runs} - ${g.home.runs}`;
+  const Tstar = marketImpliedTotal(g.markets||{});
+  const marketStr = Number.isFinite(Tstar) ? `Imp. total: ${Tstar.toFixed(1)}` : 'No market';
+
+  return `
+  <article class="game" data-id="${g.id}">
+    <div class="game__row">
+      <div class="team">
+        <img alt="${g.away.abbr} logo" src="${g.away.logo}" />
+        <div class="team__name" title="${g.away.name}">${g.away.abbr}</div>
+      </div>
+      <div class="game__score">${score}</div>
+      <div class="team" style="justify-content:end">
+        <div class="team__name" title="${g.home.name}" style="text-align:right">${g.home.abbr}</div>
+        <img alt="${g.home.abbr} logo" src="${g.home.logo}" />
+      </div>
+    </div>
+    <div class="sep"></div>
+    <div class="game__meta">
+      <div>${gameBadge(g.state)} ${g.inningStr || ''}</div>
+      <div class="game__market">
+        <span class="market-pill">${marketStr}</span>
+      </div>
+    </div>
+  </article>`;
+}
+
+function renderTicker(games){
+  // Build a long track and duplicate for seamless scroll
+  const items = games.map(g=>{
+    const tag = g.state==="final" ? "F" : (g.inningStr || g.state.toUpperCase());
+    return `<span><span class="dot"></span>${g.away.abbr} ${g.away.runs} — ${g.home.abbr} ${g.home.runs} | ${tag}</span>`;
+  }).join('');
+  elTicker.innerHTML = items + items; // duplicate for loop effect
+}
+
+async function hydrate(){
+  elGames.setAttribute('aria-busy','true');
+
+  const games = await fetchGamesSnapshot(); // plug in your backend fetch
+  // KPIs
+  const { totalRunsScored, projectedSlateFinish } = computeTwoNumbers(games);
+  elKpiTotal.textContent = Number.isFinite(totalRunsScored) ? Math.round(totalRunsScored) : '—';
+  elKpiProj.textContent  = Number.isFinite(projectedSlateFinish) ? projectedSlateFinish.toFixed(1) : '—';
+
+  // Ticker + list
+  renderTicker(games);
+  elGames.innerHTML = games.map(gameCard).join('');
+
+  elGames.removeAttribute('aria-busy');
+}
+
+// Initial load + periodic refresh
+hydrate();
+setInterval(hydrate, 30_000); // refresh every 30s
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `games.html` page with refresh controls, ticker and market-implied run projections
- ignore `node_modules` in version control

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c20511e6a8832996ac174da21c8b58