### PR TITLE
Expose raw projected total and client market lean

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -164,6 +164,11 @@
             const rem = Number(g.expected_remaining||0).toFixed(2);
             return `${g.away_team || g.away} @ ${g.home_team || g.home}: ${Number(adj).toFixed(2)} | now ${now} | exp rem ${rem} (${g.status})`;
           }).join(' · ');
+
+        const lean = (typeof p.projectedRuns === 'number' && typeof p.projectedRuns_raw === 'number')
+          ? (p.projectedRuns - p.projectedRuns_raw).toFixed(2)
+          : '—';
+        setText('lean', lean);
       }catch(e){ console.error(e); }
     }
 

--- a/server.js
+++ b/server.js
@@ -175,8 +175,10 @@ async function computeProjectionPayload() {
   }
 
   // Rollups from the SAME game set
-  const sumAdjAll = Number(games.reduce((s,g)=> s + (g.consensus_total_adj ?? g.consensus_total), 0).toFixed(2));
+  const sumAdjAll = games.reduce((s,g)=> s + (g.consensus_total_adj ?? g.consensus_total), 0);
+  const sumRawAll = games.reduce((s,g)=> s + (g.consensus_total || 0), 0);
   const projectedRuns = Number(sumAdjAll.toFixed(1)); // headline projection (consistent)
+  const projectedRunsRaw = Number(sumRawAll.toFixed(2));
 
   const actualRunsToday = mlbGames.reduce((s, g) => s + (g.runsNow || 0), 0);
 
@@ -192,7 +194,7 @@ async function computeProjectionPayload() {
 
   const payload = {
     datePT: today,
-    projectedRuns_raw: projectedRuns,
+    projectedRuns_raw: projectedRunsRaw,
     projectedRuns,
     projectedStd, bandLow, bandHigh,
     gameCountUsed: games.length,


### PR DESCRIPTION
## Summary
- Compute unadjusted sum of consensus totals on the server and expose as `projectedRuns_raw`
- Calculate market lean on the client as the difference between adjusted and raw projections

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c22d4ba770832991377d2170296c92