### PR TITLE
Add compute helper unit tests

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -1,0 +1,39 @@
+export function americanToProbRaw(american) {
+  if (american == null) return null;
+  const a = Number(american);
+  if (Number.isNaN(a) || a === 0) return null;
+  return a < 0 ? (-a) / ((-a) + 100) : 100 / (a + 100);
+}
+
+export function devigTwoWay(pOverRaw, pUnderRaw) {
+  if (pOverRaw == null || pUnderRaw == null) return null;
+  const sum = pOverRaw + pUnderRaw;
+  if (!(sum > 0)) return null;
+  return { pOver: pOverRaw / sum, pUnder: pUnderRaw / sum };
+}
+
+export function linInterp(x, x0, x1, y0, y1) {
+  if (x1 === x0) return null;
+  return y0 + (y1 - y0) * ((x - x0) / (x1 - x0));
+}
+
+export function impliedMedianFromAlts(alts) {
+  if (!Array.isArray(alts) || alts.length < 2) return null;
+  const pts = alts.map(a => {
+    const pOverRaw = americanToProbRaw(a.over);
+    const pUnderRaw = americanToProbRaw(a.under);
+    const dv = devigTwoWay(pOverRaw, pUnderRaw);
+    return { point: a.point, pOver: dv ? dv.pOver : null };
+  }).filter(a => a.pOver != null);
+  pts.sort((a,b) => a.point - b.point);
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i];
+    const b = pts[i+1];
+    if (a.pOver === 0.5) return a.point;
+    if (b.pOver === 0.5) return b.point;
+    if ((a.pOver - 0.5) * (b.pOver - 0.5) < 0) {
+      return linInterp(0.5, a.pOver, b.pOver, a.point, b.point);
+    }
+  }
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node test/compute.test.js"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/test/compute.test.js
+++ b/test/compute.test.js
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { americanToProbRaw, devigTwoWay, linInterp, impliedMedianFromAlts } from '../compute.js';
+
+// americanToProbRaw tests
+assert.strictEqual(americanToProbRaw(-150), 0.6, 'americanToProbRaw -150');
+assert.strictEqual(americanToProbRaw(200), 100 / 300, 'americanToProbRaw 200');
+
+// devigTwoWay tests
+let dv = devigTwoWay(0.55, 0.55);
+assert.deepStrictEqual(dv, { pOver: 0.5, pUnder: 0.5 }, 'devig equal probabilities');
+
+dv = devigTwoWay(0.6, 0.4);
+assert.deepStrictEqual(dv, { pOver: 0.6, pUnder: 0.4 }, 'devig preserves proportions');
+
+// linInterp tests
+assert.strictEqual(linInterp(5, 0, 10, 0, 100), 50, 'linInterp basic');
+
+// impliedMedianFromAlts tests
+const alts = [
+  { point: 8, over: -120, under: 100 },
+  { point: 9, over: 100, under: -120 }
+];
+const median = impliedMedianFromAlts(alts);
+assert.strictEqual(median, 8.5, 'median between alternating lines');
+
+const outOfRange = [
+  { point: 7, over: -150, under: 130 },
+  { point: 8, over: -130, under: 110 }
+];
+assert.strictEqual(impliedMedianFromAlts(outOfRange), null, 'out-of-range median returns null');
+
+console.log('All compute helper tests passed.');


### PR DESCRIPTION
## Summary
- add compute helper module for probability conversions and interpolation
- verify americanToProbRaw, devigTwoWay, linInterp, and impliedMedianFromAlts with Node-based tests
- expose `npm test` script using Node's assert

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c232b06ec48329a13fe85652b34df2