### PR TITLE
Add smoke test and configure test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node test/compute.test.js"
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const PORT = 3001;
+
+// Smoke test to ensure the server starts and responds to /health
+// Uses a separate port to avoid conflicts.
+test('server responds to /health', async (t) => {
+  const proc = spawn('node', ['server.js'], {
+    env: { ...process.env, PORT },
+    stdio: 'ignore'
+  });
+  t.after(() => proc.kill());
+
+  // Give the server a moment to start
+  await delay(500);
+
+  const res = await fetch(`http://localhost:${PORT}/health`);
+  assert.strictEqual(res.status, 200);
+  const data = await res.json();
+  assert.strictEqual(data.ok, true);
+});


### PR DESCRIPTION
## Summary
- run tests with `node --test`
- add smoke test for server `/health`
- ignore `node_modules`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c238804d848329ad0b0fd4ae4d0735