### PR TITLE
Add linting with ESLint and Prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "quotes": ["error", "single"],
+    "semi": ["error", "always"],
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+npm-debug.log
+.DS_Store
+.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
-# Salami Slider — Consistent Projection Build
-* Headline projected total uses the same game set as the finish number.
-* Projected Finish = Actual today + Expected remaining (per game: max(0, adj total − current runs)).
-* Stronger MLB/Odds game matching + diagnostics.
+# Salami Slider
 
-## Run
+Salami Slider provides live and projected MLB run totals.
+
+## Features
+
+- Headline projected total uses the same game set as the finish number.
+- Projected Finish = Actual today + Expected remaining (per game: max(0, adj total − current runs)).
+- Stronger MLB/Odds game matching + diagnostics.
+
+## Projection Algorithm
+
+- For each MLB game scheduled today, bookmaker totals are fetched from The Odds API.
+- American odds are converted to implied probabilities and adjusted for vig (0.60 runs per 100 points).
+- Live games only use bookmaker lines updated within the last 15 minutes.
+- Current scores from the MLB Stats API are combined with the adjusted totals to estimate expected remaining runs and the projected finish.
+- Projections are cached for 10 minutes and only refreshed between 09:00–21:00 PT.
+
+## API
+
+- `GET /api/projected-runs` – live-aware projection with expected remaining runs and diagnostics.
+- `GET /api/total-runs?date=YYYY-MM-DD` – actual runs summed for the supplied date.
+- `GET /api/scoreboard?date=YYYY-MM-DD` – basic scoreboard view.
+- `GET /health` – health check.
+
+## Environment Variables
+
+- `ODDS_API_KEY` – **required** API key for [The Odds API](https://the-odds-api.com/).
+- `PORT` – optional port for the HTTP server (defaults to `3000`).
+
+## Development
+
+```bash
 npm install
 export ODDS_API_KEY=your_key_here
 npm start
 open http://localhost:3000
+```

--- a/package.json
+++ b/package.json
@@ -4,10 +4,16 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.json . && prettier --check .",
+    "test": "node test/compute.test.js"
   },
   "dependencies": {
     "express": "^4.19.2",
     "undici": "^6.19.8"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,37 +1,176 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Salami Slider — by The Juice Junkies</title>
-  <style>body{font-family:Arial,Helvetica,sans-serif;margin:0;color:#e8eaee;background:#0c0d10}header{display:flex;align-items:center;gap:14px;padding:.6rem 1rem;background:#111;border-bottom:1px solid #242833}.wrap{max-width:1100px;margin:0 auto;padding:1rem}.card{background:#151821;border:1px solid #2b2f3a;border-radius:12px;padding:1rem;margin-bottom:12px}.big{font-size:64px;font-weight:800}#oulist{color:#a6adbb}</style>
-</head>
-<body>
-  <header><img src="juice-junkies-logo.png" alt="Juice Junkies Logo" style="height:54px;width:auto"><div style="margin-left:auto;color:#a6adbb">Live MLB Daily Total</div></header>
-  <main class="wrap">
-    <div class="card"><div>Total MLB Runs Today</div><div class="big" id="total">—</div><div>Date: <b id="date">—</b> • Games: <b id="games">—</b> • Updated: <span id="updated">—</span></div></div>
-    <div class="card"><div>Projected Total (juice-adjusted)</div><div style="font-size:40px;font-weight:800" id="proj">—</div><div>Band ±1σ: <b id="band">—</b> • Market lean: <b id="lean">—</b></div><div style="margin-top:.4rem">Actual: <b id="actual">0</b> • Projected: <b id="proj2">—</b> (<span id="pct">0%</span>)</div><div style="height:22px;border-radius:999px;border:1px solid #2b2f3a;overflow:hidden;margin-top:.4rem"><div id="bar" style="height:100%;width:0%;background:linear-gradient(90deg,#ffd166,#ff6a3d,#ff3b3b)"></div></div></div>
-    <div class="card"><div>Projected Slate Finish (Actual + Expected Remaining)</div><div style="font-size:40px;font-weight:800" id="projFinish">—</div><div>Actual today: <b id="actualToday">—</b> • Expected remaining: <b id="remainingExp">—</b></div><div id="diagLine" style="color:#a6adbb;margin-top:.3rem"></div></div>
-    <div class="card"><div>Consensus Totals (Per Game)</div><div id="oulist">—</div></div>
-  </main>
-  <script>
-    const $=id=>document.getElementById(id), setText=(id,v)=>($(id).textContent=v);
-    function fmtPT(d){ return new Intl.DateTimeFormat('en-US',{ timeZone:'America/Los_Angeles', hour:'2-digit', minute:'2-digit', second:'2-digit' }).format(d); }
-    async function getActual(){ const r = await fetch(`/api/total-runs`); if(!r.ok) throw new Error('actual'); return r.json(); }
-    async function getProj(){ const r = await fetch(`/api/projected-runs`); if(!r.ok) throw new Error('proj'); return r.json(); }
-    async function go(){
-      try{
-        const [a,p] = await Promise.all([getActual(), getProj()]);
-        const actual=a.totalRuns??0, projAdj=p.projectedRuns??0, projRaw=p.projectedRuns_raw??projAdj, low=p.bandLow??projAdj, high=p.bandHigh??projAdj;
-        setText('total',actual); setText('actual',actual); setText('games',a.gamesCount??'0'); setText('date',a.date??'—'); setText('updated',fmtPT(new Date()));
-        setText('proj',Number(projAdj).toFixed(1)); setText('proj2',Number(projAdj).toFixed(1)); setText('band',`${Number(low).toFixed(1)} – ${Number(high).toFixed(1)}`); setText('lean',`${(projAdj-projRaw)>=0?'+':''}${Number(projAdj-projRaw).toFixed(1)} runs`);
-        const pct=projAdj>0?Math.min(150,(actual/projAdj)*100):0; $('bar').style.width=`${pct.toFixed(1)}%`; setText('pct',`${(actual&&projAdj)?pct.toFixed(0):0}%`);
-        setText('projFinish', Number(p.projectedFinish||0).toFixed(2)); setText('actualToday', Number(p.actualRunsToday||0).toFixed(0)); setText('remainingExp', Number(p.remainingExpected||0).toFixed(2));
-        const d=p.diag||{}; $('diagLine').textContent=`Using ${p.gameCountUsed||0} games — Preview:${d.gamesPreview||0} Live:${d.gamesLive||0} Final:${d.gamesFinal||0}`;
-        $('oulist').textContent=(p.games||[]).map(g=>{const adj=g.consensus_total_adj??g.consensus_total;const now=Number(g.current_runs||0).toFixed(0);const rem=Number(g.expected_remaining||0).toFixed(2);return `${g.away_team||g.away} @ ${g.home_team||g.home}: ${Number(adj).toFixed(2)} | now ${now} | exp rem ${rem} (${g.status})`;}).join(' · ');
-      }catch(e){ console.error(e); }
-    }
-    go(); setInterval(go,15000);
-  </script>
-</body>
+  <!-- Live MLB run totals dashboard -->
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Salami Slider — by The Juice Junkies</title>
+    <style>
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        margin: 0;
+        color: #e8eaee;
+        background: #0c0d10;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 0.6rem 1rem;
+        background: #111;
+        border-bottom: 1px solid #242833;
+      }
+      .wrap {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 1rem;
+      }
+      .card {
+        background: #151821;
+        border: 1px solid #2b2f3a;
+        border-radius: 12px;
+        padding: 1rem;
+        margin-bottom: 12px;
+      }
+      .big {
+        font-size: 64px;
+        font-weight: 800;
+      }
+      #oulist {
+        color: #a6adbb;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <img
+        src="juice-junkies-logo.png"
+        alt="Juice Junkies Logo"
+        style="height: 54px; width: auto"
+      />
+      <div style="margin-left: auto; color: #a6adbb">Live MLB Daily Total</div>
+    </header>
+    <main class="wrap">
+      <div class="card">
+        <div>Total MLB Runs Today</div>
+        <div class="big" id="total">—</div>
+        <div>
+          Date: <b id="date">—</b> • Games: <b id="games">—</b> • Updated:
+          <span id="updated">—</span>
+        </div>
+      </div>
+      <div class="card">
+        <div>Projected Total (juice-adjusted)</div>
+        <div style="font-size: 40px; font-weight: 800" id="proj">—</div>
+        <div>
+          Band ±1σ: <b id="band">—</b> • Market lean: <b id="lean">—</b>
+        </div>
+        <div style="margin-top: 0.4rem">
+          Actual: <b id="actual">0</b> • Projected: <b id="proj2">—</b> (<span
+            id="pct"
+            >0%</span
+          >)
+        </div>
+        <div
+          style="
+            height: 22px;
+            border-radius: 999px;
+            border: 1px solid #2b2f3a;
+            overflow: hidden;
+            margin-top: 0.4rem;
+          "
+        >
+          <div
+            id="bar"
+            style="
+              height: 100%;
+              width: 0%;
+              background: linear-gradient(90deg, #ffd166, #ff6a3d, #ff3b3b);
+            "
+          ></div>
+        </div>
+      </div>
+      <div class="card">
+        <div>Projected Slate Finish (Actual + Expected Remaining)</div>
+        <div style="font-size: 40px; font-weight: 800" id="projFinish">—</div>
+        <div>
+          Actual today: <b id="actualToday">—</b> • Expected remaining:
+          <b id="remainingExp">—</b>
+        </div>
+        <div id="diagLine" style="color: #a6adbb; margin-top: 0.3rem"></div>
+      </div>
+      <div class="card">
+        <div>Consensus Totals (Per Game)</div>
+        <div id="oulist">—</div>
+      </div>
+    </main>
+    <script>
+      const $ = (id) => document.getElementById(id),
+        setText = (id, v) => ($(id).textContent = v);
+      function fmtPT(d) {
+        return new Intl.DateTimeFormat('en-US', {
+          timeZone: 'America/Los_Angeles',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }).format(d);
+      }
+      async function getActual() {
+        const r = await fetch(`/api/total-runs`);
+        if (!r.ok) throw new Error('actual');
+        return r.json();
+      }
+      async function getProj() {
+        const r = await fetch(`/api/projected-runs`);
+        if (!r.ok) throw new Error('proj');
+        return r.json();
+      }
+      async function go() {
+        try {
+          const [a, p] = await Promise.all([getActual(), getProj()]);
+          const actual = a.totalRuns ?? 0,
+            projAdj = p.projectedRuns ?? 0,
+            projRaw = p.projectedRuns_raw ?? projAdj,
+            low = p.bandLow ?? projAdj,
+            high = p.bandHigh ?? projAdj;
+          setText('total', actual);
+          setText('actual', actual);
+          setText('games', a.gamesCount ?? '0');
+          setText('date', a.date ?? '—');
+          setText('updated', fmtPT(new Date()));
+          setText('proj', Number(projAdj).toFixed(1));
+          setText('proj2', Number(projAdj).toFixed(1));
+          setText(
+            'band',
+            `${Number(low).toFixed(1)} – ${Number(high).toFixed(1)}`
+          );
+          setText(
+            'lean',
+            `${projAdj - projRaw >= 0 ? '+' : ''}${Number(projAdj - projRaw).toFixed(1)} runs`
+          );
+          const pct = projAdj > 0 ? Math.min(150, (actual / projAdj) * 100) : 0;
+          $('bar').style.width = `${pct.toFixed(1)}%`;
+          setText('pct', `${actual && projAdj ? pct.toFixed(0) : 0}%`);
+          setText('projFinish', Number(p.projectedFinish || 0).toFixed(2));
+          setText('actualToday', Number(p.actualRunsToday || 0).toFixed(0));
+          setText('remainingExp', Number(p.remainingExpected || 0).toFixed(2));
+          const d = p.diag || {};
+          $('diagLine').textContent =
+            `Using ${p.gameCountUsed || 0} games — Preview:${d.gamesPreview || 0} Live:${d.gamesLive || 0} Final:${d.gamesFinal || 0}`;
+          $('oulist').textContent = (p.games || [])
+            .map((g) => {
+              const adj = g.consensus_total_adj ?? g.consensus_total;
+              const now = Number(g.current_runs || 0).toFixed(0);
+              const rem = Number(g.expected_remaining || 0).toFixed(2);
+              return `${g.away_team || g.away} @ ${g.home_team || g.home}: ${Number(adj).toFixed(2)} | now ${now} | exp rem ${rem} (${g.status})`;
+            })
+            .join(' · ');
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      go();
+      setInterval(go, 15000);
+    </script>
+  </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,32 +1,93 @@
 // server.js — Consistent projections + projected finish
-import express from "express";
-import { fetch } from "undici";
+import express from 'express';
+import { fetch } from 'undici';
 const app = express();
 const PORT = process.env.PORT || 3000;
-const TZ = "America/Los_Angeles";
+const TZ = 'America/Los_Angeles';
 const PROJ_TTL_MS = 10 * 60 * 1000;
 const WINDOW_START_PT = 9;
-const WINDOW_END_PT   = 21;
+const WINDOW_END_PT = 21;
 const LIVE_RECENT_MIN = 15;
-const JUICE_TO_RUNS   = 0.60;
-const fmtPT = (opts) => new Intl.DateTimeFormat("en-CA", { timeZone: TZ, ...opts });
-const todayPT = () => fmtPT({ year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
-const hourPT = () => Number(fmtPT({ hour: "2-digit", hour12: false }).format(new Date()));
+const JUICE_TO_RUNS = 0.6;
+const fmtPT = (opts) =>
+  new Intl.DateTimeFormat('en-CA', { timeZone: TZ, ...opts });
+const todayPT = () =>
+  fmtPT({ year: 'numeric', month: '2-digit', day: '2-digit' }).format(
+    new Date()
+  );
+const hourPT = () =>
+  Number(fmtPT({ hour: '2-digit', hour12: false }).format(new Date()));
 const inWindow = (h = hourPT()) => h >= WINDOW_START_PT && h < WINDOW_END_PT;
-const samePTDay = (iso) => fmtPT({ year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date(iso)) === todayPT();
-const recent = (iso) => { if (!iso) return false; const ageMin = (Date.now() - new Date(iso).getTime()) / 60000; return ageMin <= LIVE_RECENT_MIN; };
-const mean = (a) => a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0;
-const std  = (a) => { if (a.length < 2) return 0; const m = mean(a); return Math.sqrt(a.reduce((s, x) => s + (x - m) ** 2, 0) / (a.length - 1)); };
-function americanToProb(american) { if (american == null) return null; const a = Number(american); if (Number.isNaN(a)) return null; return a < 0 ? (-a) / ((-a) + 100) : 100 / (a + 100); }
-function devigTwoWay(pOverRaw, pUnderRaw) { if (pOverRaw == null || pUnderRaw == null) return null; const sum = pOverRaw + pUnderRaw; if (sum <= 0) return null; return { pOver: pOverRaw / sum, pUnder: pUnderRaw / sum }; }
-const norm = (s) => (s||"").toLowerCase().replace(/[^a-z]/g,"");
-app.use(express.static("public"));
-app.get("/health", (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
-app.get("/api/total-runs", async (req, res) => {
+const samePTDay = (iso) =>
+  fmtPT({ year: 'numeric', month: '2-digit', day: '2-digit' }).format(
+    new Date(iso)
+  ) === todayPT();
+const recent = (iso) => {
+  if (!iso) return false;
+  const ageMin = (Date.now() - new Date(iso).getTime()) / 60000;
+  return ageMin <= LIVE_RECENT_MIN;
+};
+const mean = (a) => (a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0);
+const std = (a) => {
+  if (a.length < 2) return 0;
+  const m = mean(a);
+  return Math.sqrt(a.reduce((s, x) => s + (x - m) ** 2, 0) / (a.length - 1));
+};
+function americanToProb(american) {
+  if (american == null) return null;
+  const a = Number(american);
+  if (Number.isNaN(a)) return null;
+  return a < 0 ? -a / (-a + 100) : 100 / (a + 100);
+}
+function devigTwoWay(pOverRaw, pUnderRaw) {
+  if (pOverRaw == null || pUnderRaw == null) return null;
+  const sum = pOverRaw + pUnderRaw;
+  if (sum <= 0) return null;
+  return { pOver: pOverRaw / sum, pUnder: pUnderRaw / sum };
+}
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z]/g, '');
+
+function computeTwoNumbers(games) {
+  let totalRunsScored = 0;
+  let projectedSlateFinish = 0;
+  for (const g of games) {
+    totalRunsScored += g.runsSoFar || 0;
+    const pts = [];
+    for (const m of g.markets || []) {
+      const over = (m.outcomes ?? []).find((o) => /over/i.test(o.name));
+      const under = (m.outcomes ?? []).find((o) => /under/i.test(o.name));
+      const pt = over?.point ?? under?.point;
+      const pOverRaw = americanToProb(over?.price);
+      const pUnderRaw = americanToProb(under?.price);
+      const dv = devigTwoWay(pOverRaw, pUnderRaw);
+      const skew = dv ? dv.pOver - 0.5 : 0;
+      if (typeof pt === 'number') pts.push(pt + skew * JUICE_TO_RUNS);
+    }
+    const consensus = pts.length
+      ? pts.reduce((s, x) => s + x, 0) / pts.length
+      : g.runsSoFar || 0;
+    const remain =
+      g.state === 'Final' ? 0 : Math.max(0, consensus - g.runsSoFar);
+    g.consensusTotal = Number(consensus.toFixed(2));
+    projectedSlateFinish += g.runsSoFar + remain;
+  }
+  return {
+    totalRunsScored,
+    projectedSlateFinish: Number(projectedSlateFinish.toFixed(2)),
+    games,
+  };
+}
+app.use(express.static('public'));
+app.get('/health', (_req, res) =>
+  res.json({ ok: true, ts: new Date().toISOString() })
+);
+app.get('/api/total-runs', async (req, res) => {
   const date = req.query.date || todayPT();
   const url = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${date}&hydrate=linescore`;
   try {
-    const r = await fetch(url, { headers: { "User-Agent": "SalamiSlider/1.2" } });
+    const r = await fetch(url, {
+      headers: { 'User-Agent': 'SalamiSlider/1.2' },
+    });
     if (!r.ok) throw new Error(`MLB upstream ${r.status}`);
     const data = await r.json();
     const games = data?.dates?.[0]?.games ?? [];
@@ -35,123 +96,341 @@ app.get("/api/total-runs", async (req, res) => {
       const ls = g.linescore;
       totalRuns += (ls?.teams?.away?.runs ?? 0) + (ls?.teams?.home?.runs ?? 0);
     }
-    res.json({ date, gamesCount: games.length, totalRuns, lastUpdateUtc: new Date().toISOString() });
-  } catch (e) { res.status(502).json({ error: String(e) }); }
+    res.json({
+      date,
+      gamesCount: games.length,
+      totalRuns,
+      lastUpdateUtc: new Date().toISOString(),
+    });
+  } catch (e) {
+    res.status(502).json({ error: String(e) });
+  }
 });
 let projCache = { ts: 0, payload: null };
-app.get("/api/projected-runs", async (_req, res) => {
+app.get('/api/projected-runs', async (_req, res) => {
   const now = Date.now();
-  if (projCache.payload && now - projCache.ts < PROJ_TTL_MS) return res.json(projCache.payload);
-  if (!inWindow()) { if (projCache.payload) return res.json(projCache.payload); return res.json({ error: "Projection updates only between 09:00–21:00 PT" }); }
+  if (projCache.payload && now - projCache.ts < PROJ_TTL_MS)
+    return res.json(projCache.payload);
+  if (!inWindow()) {
+    if (projCache.payload) return res.json(projCache.payload);
+    return res.json({
+      error: 'Projection updates only between 09:00–21:00 PT',
+    });
+  }
   const ODDS_API_KEY = process.env.ODDS_API_KEY;
-  if (!ODDS_API_KEY) return res.status(500).json({ error: "Missing ODDS_API_KEY" });
-  const oddsUrl = new URL("https://api.the-odds-api.com/v4/sports/baseball_mlb/odds");
-  oddsUrl.searchParams.set("regions", "us"); oddsUrl.searchParams.set("markets", "totals");
-  oddsUrl.searchParams.set("oddsFormat", "american"); oddsUrl.searchParams.set("dateFormat", "iso");
-  oddsUrl.searchParams.set("apiKey", ODDS_API_KEY);
+  if (!ODDS_API_KEY)
+    return res.status(500).json({ error: 'Missing ODDS_API_KEY' });
+  const oddsUrl = new URL(
+    'https://api.the-odds-api.com/v4/sports/baseball_mlb/odds'
+  );
+  oddsUrl.searchParams.set('regions', 'us');
+  oddsUrl.searchParams.set('markets', 'totals,alternate_totals');
+  oddsUrl.searchParams.set('oddsFormat', 'american');
+  oddsUrl.searchParams.set('dateFormat', 'iso');
+  oddsUrl.searchParams.set('apiKey', ODDS_API_KEY);
   const mlbUrl = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${todayPT()}&hydrate=linescore,team,game,flags,status`;
   try {
     const [oddsResp, mlbResp] = await Promise.all([
-      fetch(oddsUrl, { headers: { "User-Agent": "SalamiSlider/1.2" } }),
-      fetch(mlbUrl,  { headers: { "User-Agent": "SalamiSlider/1.2" } }),
+      fetch(oddsUrl, { headers: { 'User-Agent': 'SalamiSlider/1.2' } }),
+      fetch(mlbUrl, { headers: { 'User-Agent': 'SalamiSlider/1.2' } }),
     ]);
     if (!oddsResp.ok) throw new Error(`Odds API ${oddsResp.status}`);
     if (!mlbResp.ok) throw new Error(`MLB upstream ${mlbResp.status}`);
     const events = await oddsResp.json();
     const mlb = await mlbResp.json();
-    const mlbGames = (mlb?.dates?.[0]?.games ?? []).map(g => ({
-      id: g.gamePk, home: g.teams?.home?.team?.name, away: g.teams?.away?.team?.name,
-      homeAbb: g.teams?.home?.team?.abbreviation, awayAbb: g.teams?.away?.team?.abbreviation,
-      state: g.status?.abstractGameState, runsNow: (g.linescore?.teams?.home?.runs ?? 0) + (g.linescore?.teams?.away?.runs ?? 0),
+    const mlbGames = (mlb?.dates?.[0]?.games ?? []).map((g) => ({
+      id: g.gamePk,
+      home: g.teams?.home?.team?.name,
+      away: g.teams?.away?.team?.name,
+      homeAbb: g.teams?.home?.team?.abbreviation,
+      awayAbb: g.teams?.away?.team?.abbreviation,
+      state: g.status?.abstractGameState,
+      runsNow:
+        (g.linescore?.teams?.home?.runs ?? 0) +
+        (g.linescore?.teams?.away?.runs ?? 0),
     }));
     const findMlb = (ev) => {
-      const h = norm(ev.home_team), a = norm(ev.away_team);
-      return mlbGames.find(g => (norm(g.home)+norm(g.homeAbb)).includes(h.slice(0,6)) &&
-                                 (norm(g.away)+norm(g.awayAbb)).includes(a.slice(0,6))) || null;
+      const h = norm(ev.home_team),
+        a = norm(ev.away_team);
+      return (
+        mlbGames.find(
+          (g) =>
+            (norm(g.home) + norm(g.homeAbb)).includes(h.slice(0, 6)) &&
+            (norm(g.away) + norm(g.awayAbb)).includes(a.slice(0, 6))
+        ) || null
+      );
     };
-    const games = []; const today = todayPT();
+    const games = [];
+    const today = todayPT();
     for (const ev of events) {
       if (!samePTDay(ev.commence_time)) continue;
       const started = new Date(ev.commence_time).getTime() <= Date.now();
-      const allPts = [], allAdjPts = [], livePts = [], liveAdjPts = [];
+      const allPts = [],
+        allAdjPts = [],
+        livePts = [],
+        liveAdjPts = [],
+        liveMain = [],
+        preMain = [],
+        liveAlts = [],
+        preAlts = [];
       for (const bk of ev.bookmakers ?? []) {
-        const m = (bk.markets ?? []).find(x => x.key === "totals"); if (!m) continue;
-        const over  = (m.outcomes ?? []).find(o => /over/i.test(o.name));
-        const under = (m.outcomes ?? []).find(o => /under/i.test(o.name));
-        const pt = over?.point ?? under?.point; if (typeof pt !== "number") continue;
-        const pOverRaw  = americanToProb(over?.price);
-        const pUnderRaw = americanToProb(under?.price);
-        const dv = devigTwoWay(pOverRaw, pUnderRaw);
-        const skew = dv ? (dv.pOver - 0.5) : 0;
-        const adjPoint = pt + skew * JUICE_TO_RUNS;
-        allPts.push(pt); allAdjPts.push(adjPoint);
-        if (started) { const lastUpd = m.last_update || bk.last_update || null; if (recent(lastUpd)) { livePts.push(pt); liveAdjPts.push(adjPoint); } }
+        const m = (bk.markets ?? []).find((x) => x.key === 'totals');
+        const mAlt = (bk.markets ?? []).find(
+          (x) => x.key === 'alternate_totals'
+        );
+        if (m) {
+          const over = (m.outcomes ?? []).find((o) => /over/i.test(o.name));
+          const under = (m.outcomes ?? []).find((o) => /under/i.test(o.name));
+          const pt = over?.point ?? under?.point;
+          if (typeof pt === 'number') {
+            const pOverRaw = americanToProb(over?.price);
+            const pUnderRaw = americanToProb(under?.price);
+            const dv = devigTwoWay(pOverRaw, pUnderRaw);
+            const skew = dv ? dv.pOver - 0.5 : 0;
+            const adjPoint = pt + skew * JUICE_TO_RUNS;
+            allPts.push(pt);
+            allAdjPts.push(adjPoint);
+            const lastUpd = m.last_update || bk.last_update || null;
+            const isLive = started && recent(lastUpd);
+            if (isLive) {
+              livePts.push(pt);
+              liveAdjPts.push(adjPoint);
+              liveMain.push({
+                book: bk.key,
+                point: pt,
+                over: over?.price ?? null,
+                under: under?.price ?? null,
+                adjPoint,
+              });
+            } else {
+              preMain.push({
+                book: bk.key,
+                point: pt,
+                over: over?.price ?? null,
+                under: under?.price ?? null,
+                adjPoint,
+              });
+            }
+          }
+        }
+        if (mAlt) {
+          const lastUpdAlt = mAlt.last_update || bk.last_update || null;
+          const isLiveAlt = started && recent(lastUpdAlt);
+          const byPoint = new Map();
+          for (const o of mAlt.outcomes ?? []) {
+            const p = o.point;
+            if (typeof p !== 'number') continue;
+            const key = String(p);
+            const cur = byPoint.get(key) || { point: p };
+            if (/over/i.test(o.name)) cur.over = o.price;
+            else if (/under/i.test(o.name)) cur.under = o.price;
+            byPoint.set(key, cur);
+          }
+          for (const { point, over, under } of byPoint.values()) {
+            if (over == null || under == null) continue;
+            const pOverRaw = americanToProb(over);
+            const pUnderRaw = americanToProb(under);
+            const dv = devigTwoWay(pOverRaw, pUnderRaw);
+            const skew = dv ? dv.pOver - 0.5 : 0;
+            const adjPoint = point + skew * JUICE_TO_RUNS;
+            const entry = { book: bk.key, point, over, under, adjPoint };
+            if (isLiveAlt) liveAlts.push(entry);
+            else preAlts.push(entry);
+          }
+        }
       }
-      const usedRaw = (started && livePts.length) ? livePts : allPts;
-      const usedAdj = (started && liveAdjPts.length) ? liveAdjPts : allAdjPts;
+      const usedRaw = started && livePts.length ? livePts : allPts;
+      const usedAdj = started && liveAdjPts.length ? liveAdjPts : allAdjPts;
       if (!usedRaw.length) continue;
       const mlbMatch = findMlb(ev);
       const runsNow = mlbMatch?.runsNow ?? 0;
-      const mlbState = mlbMatch?.state ?? (started ? "Live" : "Preview");
+      const mlbState = mlbMatch?.state ?? (started ? 'Live' : 'Preview');
       const adjMean = Number(mean(usedAdj).toFixed(2));
       const remain = adjMean - runsNow;
       games.push({
-        id: ev.id, status: mlbState, commence_time: ev.commence_time,
-        home_team: ev.home_team, away_team: ev.away_team, bookmakers_count: usedRaw.length,
+        id: ev.id,
+        status: mlbState,
+        commence_time: ev.commence_time,
+        home_team: ev.home_team,
+        away_team: ev.away_team,
+        bookmakers_count: usedRaw.length,
         consensus_total: Number(mean(usedRaw).toFixed(2)),
-        consensus_total_adj: adjMean, consensus_std: Number(std(usedRaw).toFixed(2)),
-        current_runs: runsNow, expected_remaining_raw: Number(remain.toFixed(2)),
-        expected_remaining: Number(Math.max(0, remain).toFixed(2))
+        consensus_total_adj: adjMean,
+        consensus_std: Number(std(usedRaw).toFixed(2)),
+        current_runs: runsNow,
+        expected_remaining_raw: Number(remain.toFixed(2)),
+        expected_remaining: Number(Math.max(0, remain).toFixed(2)),
+        liveMain,
+        preMain,
+        liveAlts,
+        preAlts,
       });
     }
-    const sumAdjAll = Number(games.reduce((s,g)=> s + (g.consensus_total_adj ?? g.consensus_total), 0).toFixed(2));
+    const sumAdjAll = Number(
+      games
+        .reduce((s, g) => s + (g.consensus_total_adj ?? g.consensus_total), 0)
+        .toFixed(2)
+    );
     const projectedRuns = Number(sumAdjAll.toFixed(1));
     const actualRunsToday = mlbGames.reduce((s, g) => s + (g.runsNow || 0), 0);
     const remainingExpected = Number(
-      games.filter(g => g.status !== "Final").reduce((s,g)=> s + (g.expected_remaining || 0), 0).toFixed(2)
+      games
+        .filter((g) => g.status !== 'Final')
+        .reduce((s, g) => s + (g.expected_remaining || 0), 0)
+        .toFixed(2)
     );
-    const projectedFinish = Number((actualRunsToday + remainingExpected).toFixed(2));
-    const projectedStd  = Number(Math.sqrt(games.reduce((s, g) => s + (g.consensus_std ** 2 || 0), 0)).toFixed(1));
-    const bandLow  = Number((projectedRuns - projectedStd).toFixed(1));
+    const projectedFinish = Number(
+      (actualRunsToday + remainingExpected).toFixed(2)
+    );
+    const projectedStd = Number(
+      Math.sqrt(
+        games.reduce((s, g) => s + (g.consensus_std ** 2 || 0), 0)
+      ).toFixed(1)
+    );
+    const bandLow = Number((projectedRuns - projectedStd).toFixed(1));
     const bandHigh = Number((projectedRuns + projectedStd).toFixed(1));
     const payload = {
-      datePT: today, projectedRuns_raw: projectedRuns, projectedRuns,
-      projectedStd, bandLow, bandHigh, gameCountUsed: games.length, games,
-      actualRunsToday, remainingExpected, projectedFinish,
-      source: "The Odds API + MLB Stats API (live-aware, juice-adjusted)",
+      datePT: today,
+      projectedRuns_raw: projectedRuns,
+      projectedRuns,
+      projectedStd,
+      bandLow,
+      bandHigh,
+      gameCountUsed: games.length,
+      games,
+      actualRunsToday,
+      remainingExpected,
+      projectedFinish,
+      source: 'The Odds API + MLB Stats API (live-aware, juice-adjusted)',
       lastUpdateUtc: new Date().toISOString(),
-      diag: { sumAdjAll: projectedRuns, gamesPreview: games.filter(g=>g.status==='Preview').length, gamesLive: games.filter(g=>g.status==='Live').length, gamesFinal: games.filter(g=>g.status==='Final').length },
-      config: { windowStartPT: WINDOW_START_PT, windowEndPT: WINDOW_END_PT, cacheMinutes: PROJ_TTL_MS/60000, liveRecentMinutes: LIVE_RECENT_MIN, juiceToRuns: JUICE_TO_RUNS }
+      diag: {
+        sumAdjAll: projectedRuns,
+        gamesPreview: games.filter((g) => g.status === 'Preview').length,
+        gamesLive: games.filter((g) => g.status === 'Live').length,
+        gamesFinal: games.filter((g) => g.status === 'Final').length,
+      },
+      config: {
+        windowStartPT: WINDOW_START_PT,
+        windowEndPT: WINDOW_END_PT,
+        cacheMinutes: PROJ_TTL_MS / 60000,
+        liveRecentMinutes: LIVE_RECENT_MIN,
+        juiceToRuns: JUICE_TO_RUNS,
+      },
     };
     projCache = { ts: now, payload };
     res.json(payload);
-  } catch (e) { res.status(502).json({ error: String(e) }); }
+  } catch (e) {
+    res.status(502).json({ error: String(e) });
+  }
 });
-app.get("/api/scoreboard", async (req, res) => {
+
+app.get('/api/projection', async (_req, res) => {
+  const ODDS_API_KEY = process.env.ODDS_API_KEY;
+  if (!ODDS_API_KEY)
+    return res.status(500).json({ error: 'Missing ODDS_API_KEY' });
+  const oddsUrl = new URL(
+    'https://api.the-odds-api.com/v4/sports/baseball_mlb/odds'
+  );
+  oddsUrl.searchParams.set('regions', 'us');
+  oddsUrl.searchParams.set('markets', 'totals,alternate_totals');
+  oddsUrl.searchParams.set('oddsFormat', 'american');
+  oddsUrl.searchParams.set('dateFormat', 'iso');
+  oddsUrl.searchParams.set('apiKey', ODDS_API_KEY);
+  const mlbUrl = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${todayPT()}&hydrate=linescore,team,game,flags,status`;
+  try {
+    const [oddsResp, mlbResp] = await Promise.all([
+      fetch(oddsUrl, { headers: { 'User-Agent': 'SalamiSlider/1.2' } }),
+      fetch(mlbUrl, { headers: { 'User-Agent': 'SalamiSlider/1.2' } }),
+    ]);
+    if (!oddsResp.ok) throw new Error(`Odds API ${oddsResp.status}`);
+    if (!mlbResp.ok) throw new Error(`MLB upstream ${mlbResp.status}`);
+    const events = await oddsResp.json();
+    const mlb = await mlbResp.json();
+    const mlbGames = (mlb?.dates?.[0]?.games ?? []).map((g) => ({
+      home: g.teams?.home?.team?.name,
+      away: g.teams?.away?.team?.name,
+      homeAbb: g.teams?.home?.team?.abbreviation,
+      awayAbb: g.teams?.away?.team?.abbreviation,
+      state: g.status?.abstractGameState,
+      runsSoFar:
+        (g.linescore?.teams?.home?.runs ?? 0) +
+        (g.linescore?.teams?.away?.runs ?? 0),
+    }));
+    const findMlb = (ev) => {
+      const h = norm(ev.home_team),
+        a = norm(ev.away_team);
+      return (
+        mlbGames.find(
+          (g) =>
+            (norm(g.home) + norm(g.homeAbb)).includes(h.slice(0, 6)) &&
+            (norm(g.away) + norm(g.awayAbb)).includes(a.slice(0, 6))
+        ) || null
+      );
+    };
+    const games = [];
+    for (const ev of events) {
+      if (!samePTDay(ev.commence_time)) continue;
+      const match = findMlb(ev);
+      if (!match) continue;
+      const markets = [];
+      for (const bk of ev.bookmakers ?? []) {
+        for (const m of bk.markets ?? []) {
+          if (m.key === 'totals' || m.key === 'alternate_totals') {
+            markets.push(m);
+          }
+        }
+      }
+      games.push({ state: match.state, runsSoFar: match.runsSoFar, markets });
+    }
+    const result = computeTwoNumbers(games);
+    res.json(result);
+  } catch (e) {
+    res.status(502).json({ error: String(e) });
+  }
+});
+app.get('/api/scoreboard', async (req, res) => {
   const date = req.query.date || todayPT();
   const url = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${date}&hydrate=linescore,team,game,flags,status`;
   try {
-    const r = await fetch(url, { headers: { "User-Agent": "SalamiSlider/1.2" } });
+    const r = await fetch(url, {
+      headers: { 'User-Agent': 'SalamiSlider/1.2' },
+    });
     if (!r.ok) throw new Error(`MLB upstream ${r.status}`);
     const data = await r.json();
     const games = data?.dates?.[0]?.games ?? [];
     const items = games.map((g) => {
-      const home = g.teams?.home?.team?.abbreviation || g.teams?.home?.team?.name || "HOME";
-      const away = g.teams?.away?.team?.abbreviation || g.teams?.away?.team?.name || "AWAY";
+      const home =
+        g.teams?.home?.team?.abbreviation ||
+        g.teams?.home?.team?.name ||
+        'HOME';
+      const away =
+        g.teams?.away?.team?.abbreviation ||
+        g.teams?.away?.team?.name ||
+        'AWAY';
       const hs = g.linescore?.teams?.home?.runs ?? 0;
       const as = g.linescore?.teams?.away?.runs ?? 0;
       const state = g.status?.abstractGameState;
       const detailed = g.status?.detailedState;
-      let tag = "";
-      if (state === "Preview") tag = "Scheduled";
-      else if (state === "Live") { const inning = g.linescore?.currentInning; const half = g.linescore?.isTopInning ? "Top" : "Bot"; const outs = g.linescore?.outs ?? 0; tag = `${half} ${inning}, ${outs} out${outs === 1 ? "" : "s"}`; }
-      else if (state === "Final") { const ord = g.linescore?.currentInningOrdinal || "F"; tag = ord; }
-      else tag = detailed || state || "";
+      let tag = '';
+      if (state === 'Preview') tag = 'Scheduled';
+      else if (state === 'Live') {
+        const inning = g.linescore?.currentInning;
+        const half = g.linescore?.isTopInning ? 'Top' : 'Bot';
+        const outs = g.linescore?.outs ?? 0;
+        tag = `${half} ${inning}, ${outs} out${outs === 1 ? '' : 's'}`;
+      } else if (state === 'Final') {
+        const ord = g.linescore?.currentInningOrdinal || 'F';
+        tag = ord;
+      } else tag = detailed || state || '';
       return { id: g.gamePk, away, as, home, hs, state, tag };
     });
-    const ord = (s) => (s === "Live" ? 0 : s === "Preview" ? 1 : 2);
+    const ord = (s) => (s === 'Live' ? 0 : s === 'Preview' ? 1 : 2);
     items.sort((a, b) => ord(a.state) - ord(b.state));
     res.json({ date, items, lastUpdateUtc: new Date().toISOString() });
-  } catch (e) { res.status(502).json({ error: String(e) }); }
+  } catch (e) {
+    res.status(502).json({ error: String(e) });
+  }
 });
-app.listen(PORT, () => console.log(`Server listening on http://localhost:${PORT}`));
+app.listen(PORT, () =>
+  console.log(`Server listening on http://localhost:${PORT}`)
+);

--- a/test/compute.test.js
+++ b/test/compute.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic arithmetic', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- restore complete README with features, projection algorithm, API, and setup instructions
- add `.eslintrc.json` and wire up lint/test scripts in package.json
- include a simple Node test to exercise the new `npm test` script
- document the front-end by adding a comment at the top of `public/index.html`
- expand projection API to include alternate totals and expose a new `/api/projection` endpoint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c232b1818c8329bcd3f83b34494692