### PR TITLE
docs: expand README with features and setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,44 @@
 
 Salami Slider provides live and projected MLB run totals.
 
+## Features
+
+- Headline projected total uses the same game set as the finish number.
+- Projected Finish = Actual today + Expected remaining (per game: max(0, adj total − current runs)).
+- Stronger MLB/Odds game matching + diagnostics.
+
 ## Projection Algorithm
 
-* For each MLB game scheduled today, bookmaker totals are fetched from The Odds API.
-* American odds are converted to implied probabilities and adjusted for vig (0.60 runs per 100 points).
-* Live games only use bookmaker lines updated within the last 15 minutes.
-* Current scores from the MLB Stats API are combined with the adjusted totals to estimate expected remaining runs and the projected finish.
-* Projections are cached for 10 minutes and only refreshed between 09:00–21:00 PT.
+- For each MLB game scheduled today, bookmaker totals are fetched from The Odds API.
+- American odds are converted to implied probabilities and adjusted for vig (0.60 runs per 100 points).
+- Live games only use bookmaker lines updated within the last 15 minutes.
+- Current scores from the MLB Stats API are combined with the adjusted totals to estimate expected remaining runs and the projected finish.
+- Projections are cached for 10 minutes and only refreshed between 09:00–21:00 PT.
 
 ## API
 
-* `GET /api/projected-runs` – live-aware projection with expected remaining runs and diagnostics.
-* `GET /api/total-runs?date=YYYY-MM-DD` – actual runs summed for the supplied date.
-* `GET /api/scoreboard?date=YYYY-MM-DD` – basic scoreboard view.
-* `GET /health` – health check.
+- `GET /api/projected-runs` – live-aware projection with expected remaining runs and diagnostics.
+- `GET /api/total-runs?date=YYYY-MM-DD` – actual runs summed for the supplied date.
+- `GET /api/scoreboard?date=YYYY-MM-DD` – basic scoreboard view.
+- `GET /health` – health check.
 
 ## Environment Variables
 
-* `ODDS_API_KEY` – **required** API key for [The Odds API](https://the-odds-api.com/).
-* `PORT` – optional port for the HTTP server (defaults to `3000`).
+- `ODDS_API_KEY` – **required** API key for [The Odds API](https://the-odds-api.com/).
+- `PORT` – optional port for the HTTP server (defaults to `3000`).
 
 ## Development
 
 ```bash
 npm install
+export ODDS_API_KEY=your_key_here
 npm start
 ```
 
-### Tests and Linting
+Open http://localhost:3000 after starting the server.
+
+### Tests
 
 ```bash
 npm test       # run unit tests
-npm run lint   # run ESLint
 ```
-
-Open http://localhost:3000 after starting the server.


### PR DESCRIPTION
## Summary
- detail app features in README
- document projection algorithm, API, env vars, and development steps

## Testing
- `npx prettier --write README.md`
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c23b21e15c8329a5511c3a58f04d8b