### PR TITLE
chore: add trailing commas for eslint

### DIFF
--- a/server.js
+++ b/server.js
@@ -150,15 +150,15 @@ app.get("/api/projected-runs", async (_req, res) => {
       const mlbState = mlbMatch?.state ?? (started ? "Live" : "Preview");
       const adjMean = Number(mean(usedAdj).toFixed(2));
       const remain = adjMean - runsNow;
-      games.push({
-        id: ev.id, status: mlbState, commence_time: ev.commence_time,
-        home_team: ev.home_team, away_team: ev.away_team, bookmakers_count: usedRaw.length,
-        consensus_total: Number(mean(usedRaw).toFixed(2)),
-        consensus_total_adj: adjMean, consensus_std: Number(std(usedRaw).toFixed(2)),
-        current_runs: runsNow, expected_remaining_raw: Number(remain.toFixed(2)),
-        expected_remaining: Number(Math.max(0, remain).toFixed(2)),
-        liveMain, preMain, liveAlts, preAlts
-      });
+        games.push({
+          id: ev.id, status: mlbState, commence_time: ev.commence_time,
+          home_team: ev.home_team, away_team: ev.away_team, bookmakers_count: usedRaw.length,
+          consensus_total: Number(mean(usedRaw).toFixed(2)),
+          consensus_total_adj: adjMean, consensus_std: Number(std(usedRaw).toFixed(2)),
+          current_runs: runsNow, expected_remaining_raw: Number(remain.toFixed(2)),
+          expected_remaining: Number(Math.max(0, remain).toFixed(2)),
+          liveMain, preMain, liveAlts, preAlts,
+        });
     }
     const sumAdjAll = Number(games.reduce((s,g)=> s + (g.consensus_total_adj ?? g.consensus_total), 0).toFixed(2));
     const projectedRuns = Number(sumAdjAll.toFixed(1));
@@ -176,9 +176,15 @@ app.get("/api/projected-runs", async (_req, res) => {
       actualRunsToday, remainingExpected, projectedFinish,
       source: "The Odds API + MLB Stats API (live-aware, juice-adjusted)",
       lastUpdateUtc: new Date().toISOString(),
-      diag: { sumAdjAll: projectedRuns, gamesPreview: games.filter(g=>g.status==='Preview').length, gamesLive: games.filter(g=>g.status==='Live').length, gamesFinal: games.filter(g=>g.status==='Final').length },
-      config: { windowStartPT: WINDOW_START_PT, windowEndPT: WINDOW_END_PT, cacheMinutes: PROJ_TTL_MS/60000, liveRecentMinutes: LIVE_RECENT_MIN, juiceToRuns: JUICE_TO_RUNS }
-    };
+        diag: { sumAdjAll: projectedRuns, gamesPreview: games.filter(g=>g.status==='Preview').length, gamesLive: games.filter(g=>g.status==='Live').length, gamesFinal: games.filter(g=>g.status==='Final').length },
+        config: {
+          windowStartPT: WINDOW_START_PT,
+          windowEndPT: WINDOW_END_PT,
+          cacheMinutes: PROJ_TTL_MS/60000,
+          liveRecentMinutes: LIVE_RECENT_MIN,
+          juiceToRuns: JUICE_TO_RUNS,
+        },
+      };
     projCache = { ts: now, payload };
     res.json(payload);
   } catch (e) { res.status(502).json({ error: String(e) }); }

--- a/test/compute.test.js
+++ b/test/compute.test.js
@@ -16,17 +16,17 @@ assert.deepStrictEqual(dv, { pOver: 0.6, pUnder: 0.4 }, 'devig preserves proport
 assert.strictEqual(linInterp(5, 0, 10, 0, 100), 50, 'linInterp basic');
 
 // impliedMedianFromAlts tests
-const alts = [
-  { point: 8, over: -120, under: 100 },
-  { point: 9, over: 100, under: -120 }
-];
+  const alts = [
+    { point: 8, over: -120, under: 100 },
+    { point: 9, over: 100, under: -120 },
+  ];
 const median = impliedMedianFromAlts(alts);
 assert.strictEqual(median, 8.5, 'median between alternating lines');
 
-const outOfRange = [
-  { point: 7, over: -150, under: 130 },
-  { point: 8, over: -130, under: 110 }
-];
+  const outOfRange = [
+    { point: 7, over: -150, under: 130 },
+    { point: 8, over: -130, under: 110 },
+  ];
 assert.strictEqual(impliedMedianFromAlts(outOfRange), null, 'out-of-range median returns null');
 
 console.log('All compute helper tests passed.');

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -8,10 +8,10 @@ const PORT = 3001;
 // Smoke test to ensure the server starts and responds to /health
 // Uses a separate port to avoid conflicts.
 test('server responds to /health', async (t) => {
-  const proc = spawn('node', ['server.js'], {
-    env: { ...process.env, PORT },
-    stdio: 'ignore'
-  });
+    const proc = spawn('node', ['server.js'], {
+      env: { ...process.env, PORT },
+      stdio: 'ignore',
+    });
   t.after(() => proc.kill());
 
   // Give the server a moment to start


### PR DESCRIPTION
## Summary
- add trailing comma in `config` object
- standardize trailing commas in tests for lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c243e2d1e083299c889d88a403d197